### PR TITLE
Fix SDK provider loading

### DIFF
--- a/providers_darwin.go
+++ b/providers_darwin.go
@@ -1,0 +1,7 @@
+//go:build darwin
+
+package sindoq
+
+import (
+	_ "github.com/happyhackingspace/sindoq/internal/provider/seatbelt"
+)

--- a/providers_linux.go
+++ b/providers_linux.go
@@ -1,0 +1,10 @@
+//go:build linux
+
+package sindoq
+
+import (
+	_ "github.com/happyhackingspace/sindoq/internal/provider/firecracker"
+	_ "github.com/happyhackingspace/sindoq/internal/provider/gvisor"
+	_ "github.com/happyhackingspace/sindoq/internal/provider/landlock"
+	_ "github.com/happyhackingspace/sindoq/internal/provider/nsjail"
+)

--- a/sindoq.go
+++ b/sindoq.go
@@ -28,6 +28,14 @@ import (
 	"github.com/happyhackingspace/sindoq/pkg/executor"
 	"github.com/happyhackingspace/sindoq/pkg/fs"
 	"github.com/happyhackingspace/sindoq/pkg/langdetect"
+
+	// Register cross-platform providers so they are available when using sindoq as a library.
+	_ "github.com/happyhackingspace/sindoq/internal/provider/docker"
+	_ "github.com/happyhackingspace/sindoq/internal/provider/e2b"
+	_ "github.com/happyhackingspace/sindoq/internal/provider/kubernetes"
+	_ "github.com/happyhackingspace/sindoq/internal/provider/podman"
+	_ "github.com/happyhackingspace/sindoq/internal/provider/vercel"
+	_ "github.com/happyhackingspace/sindoq/internal/provider/wasmer"
 )
 
 // Sandbox represents an isolated code execution environment.


### PR DESCRIPTION
## Summary
- Register all providers via blank imports in the root `sindoq` package so they are available when using sindoq as a library
- Add platform-specific provider imports via `providers_linux.go` and `providers_darwin.go`

Fixes #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced provider registration and initialization system to ensure proper provider loading across macOS and Linux platforms and when used as a library dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->